### PR TITLE
fix(cli): empty .macf/plugin/ should trigger repair fetch

### DIFF
--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -6,7 +6,7 @@
  * version pins, this command is the canonical bumper.
  */
 import { createInterface } from 'node:readline';
-import { existsSync } from 'node:fs';
+import { existsSync, readdirSync } from 'node:fs';
 import { readAgentConfig, writeAgentConfig } from '../config.js';
 import { resolveLatestVersions } from '../version-resolver.js';
 import { copyCanonicalRules, copyCanonicalScripts } from '../rules.js';
@@ -61,6 +61,17 @@ export function buildDiff(
       status: cur === lat ? ('same' as const) : ('update' as const),
     };
   });
+}
+
+/**
+ * Does the .macf/plugin/ dir need a re-fetch? True if the dir doesn't
+ * exist OR exists but is empty. `existsSync` alone returns true for an
+ * empty dir, which misses the repair case (e.g. workspaces init'd before
+ * #60 merged where the directory was created but never populated).
+ */
+function pluginDirNeedsRepair(dir: string): boolean {
+  if (!existsSync(dir)) return true;
+  return readdirSync(dir).length === 0;
 }
 
 function formatRow(row: DiffRow): string {
@@ -128,6 +139,22 @@ export async function update(
   const refreshedScripts = copyCanonicalScripts(projectDir);
   if (refreshedScripts.length > 0) {
     console.log(`Refreshed ${refreshedScripts.length} helper script(s) in .claude/scripts/`);
+  }
+
+  // Repair-case plugin fetch: if .macf/plugin/ is absent or empty, fetch
+  // the currently-pinned version regardless of whether anything is being
+  // bumped. Runs before every short-circuit so workspaces init'd before
+  // #60 merged (empty .macf/plugin/) don't require `rm -rf + macf update`
+  // to self-heal. See #62. We skip this if config.versions is missing —
+  // legacy configs are handled by the error path below.
+  if (config.versions && pluginDirNeedsRepair(workspacePluginDir(projectDir))) {
+    try {
+      fetchPluginToWorkspace(projectDir, config.versions.plugin);
+      console.log(`Repaired .macf/plugin/ with macf-agent@v${config.versions.plugin}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`Warning: plugin repair fetch failed: ${msg}`);
+    }
   }
 
   if (!config.versions) {
@@ -200,15 +227,11 @@ export async function update(
 
   writeAgentConfig(projectDir, { ...config, versions: newVersions });
 
-  // Re-fetch the plugin if versions.plugin was bumped OR the plugin dir
-  // is missing (repair case: user bumped pin earlier but fetch failed,
-  // or workspace was cloned without .macf/plugin/). Unlike rules/scripts,
-  // plugin fetch is a network clone — we don't want to do it on every
-  // `macf update` unconditionally, only when the pin actually changed
-  // (or needs to).
+  // Re-fetch the plugin when versions.plugin was bumped. The separate
+  // repair-case fetch runs earlier (before short-circuits) for empty/
+  // missing dirs; this block handles the pin-bump case specifically.
   const pluginBumped = toBump.some(r => r.component === 'plugin');
-  const pluginMissing = !existsSync(workspacePluginDir(projectDir));
-  if (pluginBumped || pluginMissing) {
+  if (pluginBumped) {
     try {
       fetchPluginToWorkspace(projectDir, newVersions.plugin);
       console.log(`Refreshed .macf/plugin/ to macf-agent@v${newVersions.plugin}`);

--- a/test/cli/update.test.ts
+++ b/test/cli/update.test.ts
@@ -5,8 +5,19 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { join } from 'node:path';
 import { existsSync, mkdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+
+// Stub the plugin fetcher for the whole file — otherwise any test that
+// bumps a pin would trigger a real `git clone` of groundnuty/macf-marketplace,
+// making tests network-dependent and slow. workspacePluginDir still returns
+// a real path so the repair-case predicate can inspect it.
+vi.mock('../../src/cli/plugin-fetcher.js', () => ({
+  fetchPluginToWorkspace: vi.fn(),
+  workspacePluginDir: (dir: string) => join(dir, '.macf', 'plugin'),
+}));
+
 import { update, buildDiff, renderDiff } from '../../src/cli/commands/update.js';
 import { agentConfigPath } from '../../src/cli/config.js';
+import { fetchPluginToWorkspace } from '../../src/cli/plugin-fetcher.js';
 import type { ResolvedVersions } from '../../src/cli/version-resolver.js';
 import type { MacfAgentConfig } from '../../src/cli/config.js';
 
@@ -229,6 +240,39 @@ describe('update command', () => {
     expect(code).toBe(1);
     expect(existsSync(join(dir, '.claude', 'rules', 'coordination.md'))).toBe(true);
     expect(existsSync(join(dir, '.claude', 'scripts', 'tmux-send-to-claude.sh'))).toBe(true);
+  });
+
+  it('re-fetches plugin when .macf/plugin/ is present but empty (#62 repair)', async () => {
+    // Workspace init'd before PR #60 merged: .macf/plugin/ exists as an
+    // empty directory. existsSync is true, but pluginDirNeedsRepair must
+    // still treat it as broken.
+    writeConfig(dir, { cli: '0.2.0', plugin: '0.1.0', actions: 'v1' });
+    mkdirSync(join(dir, '.macf', 'plugin'), { recursive: true });
+    // Nothing bumped — same versions returned by the "latest" fetch.
+    mockFetchReturning({ cli: '0.2.0', plugin: '0.1.0', actions: 'v1' });
+
+    vi.mocked(fetchPluginToWorkspace).mockClear();
+    const code = await update(dir, { all: false, cli: false, plugin: false, actions: false, yes: false, dryRun: false });
+    expect(code).toBe(0);
+
+    // Repair case: fetch should have been invoked exactly once with the
+    // pinned version even though nothing was bumped.
+    expect(fetchPluginToWorkspace).toHaveBeenCalledTimes(1);
+    expect(fetchPluginToWorkspace).toHaveBeenCalledWith(dir, '0.1.0');
+  });
+
+  it('does not re-fetch plugin when .macf/plugin/ is populated and no bump happens', async () => {
+    // Healthy workspace: .macf/plugin/ has content, pins match latest.
+    // Should short-circuit without any plugin refresh.
+    writeConfig(dir, { cli: '0.2.0', plugin: '0.1.0', actions: 'v1' });
+    mkdirSync(join(dir, '.macf', 'plugin'), { recursive: true });
+    writeFileSync(join(dir, '.macf', 'plugin', 'manifest.txt'), 'v0.1.0\n');
+    mockFetchReturning({ cli: '0.2.0', plugin: '0.1.0', actions: 'v1' });
+
+    vi.mocked(fetchPluginToWorkspace).mockClear();
+    await update(dir, { all: false, cli: false, plugin: false, actions: false, yes: false, dryRun: false });
+
+    expect(fetchPluginToWorkspace).not.toHaveBeenCalled();
   });
 
   it('preserves unrelated config fields when writing', async () => {


### PR DESCRIPTION
Refs #62

## Bug

PR #60's repair check used \`\!existsSync(workspacePluginDir(projectDir))\`, which returns \`true\` only when the dir is absent. An empty directory passes \`existsSync\`, so workspaces init'd before #60 merged — where \`macf init\` created \`.macf/plugin/\` but never populated it — never self-healed. Phase 5 CV audit found cv-architect and cv-project-archaeologist in this state.

## Fix

- Extract \`pluginDirNeedsRepair(dir)\` predicate: returns true when absent OR empty.
- Move the repair-case fetch to run **before** any short-circuit in \`update()\`. Previously the \`candidates.length === 0\` early return fired before the plugin block was reached, so even the right predicate wouldn't help when nothing was bumped. Same pattern as #52's unconditional rules refresh.
- The pin-bump fetch stays in place after \`writeAgentConfig\` for the actual bump case.

## Tests

- New: empty \`.macf/plugin/\` + no version bumps → exactly one fetch call with pinned version.
- New: populated dir + no bumps → no fetch (preserves #60's \"only on demand\" semantic).
- File-level \`vi.mock('plugin-fetcher')\` prevents all existing tests from triggering real git clones. This was previously implicit (tests happened to work because some paths short-circuited before fetch). Now explicit and deterministic — no network in the unit test suite.

## Test plan

- [x] \`make -f dev.mk check\` — 329/329 pass, clean tsc + eslint
- [ ] Manual: \`rm -rf <workspace>/.macf/plugin && mkdir <workspace>/.macf/plugin && macf update\` — should log \`Repaired .macf/plugin/ with macf-agent@v<pinned>\` and populate the dir
- [ ] Manual: healthy workspace (populated plugin dir, pins match) → \`macf update\` logs \"Everything is up to date\" with no mention of plugin refresh

Tiny diff, isolated to \`update.ts\` + \`update.test.ts\`.